### PR TITLE
Remove bitcoin-internals dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -204,7 +204,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "bitcoin",
- "bitcoin-internals",
  "hex-conservative",
  "miniscript",
  "secp256k1",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -200,7 +200,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "bitcoin",
- "bitcoin-internals",
  "hex-conservative",
  "miniscript",
  "secp256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["std"]
-std = ["bitcoin/std", "bitcoin-internals/std", "miniscript?/std"]
+std = ["bitcoin/std", "miniscript?/std"]
 rand = ["std", "bitcoin/rand-std"]
-serde = ["dep:actual-serde", "bitcoin/serde", "bitcoin-internals/serde"]
+serde = ["dep:actual-serde", "bitcoin/serde"]
 base64 = ["bitcoin/base64"]
 miniscript = ["dep:miniscript", "miniscript?/no-std"]
 
 [dependencies]
 bitcoin = { version = "0.32.6", default-features = false }
-bitcoin-internals = { version = "0.3.0", features = ["alloc"] }
 # Workaround for minimal version resolution bug in bitcoin 0.32.x series.
 # bitcoin 0.32.6 depends on hex-conservative 0.2.0, which incorrectly specifies
 # arrayvec = "0.7" instead of "0.7.2". Is fixed in hex-conservative 0.2.1.

--- a/src/v0/bitcoin/mod.rs
+++ b/src/v0/bitcoin/mod.rs
@@ -853,7 +853,9 @@ pub enum GetKeyError {
     NotSupported,
 }
 
-bitcoin_internals::impl_from_infallible!(GetKeyError);
+impl From<core::convert::Infallible> for GetKeyError {
+    fn from(never: core::convert::Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for GetKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -966,7 +968,9 @@ pub enum SignError {
     Unsupported,
 }
 
-bitcoin_internals::impl_from_infallible!(SignError);
+impl From<core::convert::Infallible> for SignError {
+    fn from(never: core::convert::Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for SignError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1055,7 +1059,9 @@ pub enum ExtractTxError {
     },
 }
 
-bitcoin_internals::impl_from_infallible!(ExtractTxError);
+impl From<core::convert::Infallible> for ExtractTxError {
+    fn from(never: core::convert::Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for ExtractTxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1107,7 +1113,9 @@ pub enum IndexOutOfBoundsError {
     },
 }
 
-bitcoin_internals::impl_from_infallible!(IndexOutOfBoundsError);
+impl From<core::convert::Infallible> for IndexOutOfBoundsError {
+    fn from(never: core::convert::Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for IndexOutOfBoundsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1160,7 +1168,9 @@ mod display_from_str {
         Base64Encoding(bitcoin::base64::DecodeError),
     }
 
-    bitcoin_internals::impl_from_infallible!(PsbtParseError);
+    impl From<core::convert::Infallible> for PsbtParseError {
+        fn from(never: core::convert::Infallible) -> Self { match never {} }
+    }
 
     impl Display for PsbtParseError {
         fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Just me or does it feel a little weird to be depending on `internals` over here? It was simple enough to remove and would be one less dependency rule to deal with.