### PR TITLE
Add missing PSBT_IN_NON_WITNESS_UTXO to v2 input decoding

### DIFF
--- a/src/v2/map/input.rs
+++ b/src/v2/map/input.rs
@@ -457,6 +457,11 @@ impl Input {
                     self.min_height <= <raw_key: _>|<raw_value: absolute::Height>
                 }
             }
+            PSBT_IN_NON_WITNESS_UTXO => {
+                v2_impl_psbt_insert_pair! {
+                    self.non_witness_utxo <= <raw_key: _>|<raw_value: Transaction>
+                }
+            }
             PSBT_IN_WITNESS_UTXO => {
                 v2_impl_psbt_insert_pair! {
                     self.witness_utxo <= <raw_key: _>|<raw_value: TxOut>


### PR DESCRIPTION
This PR adds the missing PSBT_IN_NON_WITNESS_UTXO key type to the insert_pair match in v2::Input.

Looks like the decode path was missing since the original "Add PSBT v2" commit.