### PR TITLE
Github actions only understand full hash revs

### DIFF
--- a/.github/workflows/update-toolchains.yml
+++ b/.github/workflows/update-toolchains.yml
@@ -14,5 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/update-nightly@320a06a
-      - uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/update-stable@320a06a
+      - uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/update-nightly@320a06a6647c90ac97452b20fad5b689905a9791
+      - uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/update-stable@320a06a6647c90ac97452b20fad5b689905a9791


### PR DESCRIPTION
Lesson learned, github actions only supports full hashes.