### PR TITLE
Use repository secret instead of default token

### DIFF
--- a/.github/workflows/update-toolchains.yml
+++ b/.github/workflows/update-toolchains.yml
@@ -15,4 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/update-nightly@320a06a6647c90ac97452b20fad5b689905a9791
+        with:
+          token: ${{ secrets.RBMT_PRS }}
       - uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/update-stable@320a06a6647c90ac97452b20fad5b689905a9791
+        with:
+          token: ${{ secrets.RBMT_PRS }}


### PR DESCRIPTION
Without setting a `token` the job uses the default `GITHUB_TOKEN` of the repository. But this only works if the "Allow GitHub Actions to create and approve pull requests" is enabled on the repository. I don't have perms to see if it is here on `rust-psbt`, but I bet it isn't. And I bet it *is* enabled over on `rust-bitcoin-maintainer-tools` which is why it worked over there.

In any case, it is probably better to keep that setting disabled and use a user account PAT with just repo permission. I added mine to the `RBMT_PRS` secret in this repository (which I had permissions to do). Updating the job to use it.

I have a PR open on the rbmt side to document these fun little github quirks: https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/pull/79