### PR TITLE
Convert `bip32_derivation` fields to `bitcoin::PublicKey`

### DIFF
--- a/api/all-features.txt
+++ b/api/all-features.txt
@@ -950,7 +950,7 @@ pub fn psbt_v2::v0::bitcoin::SigningKeys::from(t: T) -> T
 impl<V, T> ppv_lite86::types::VZip<V> for psbt_v2::v0::bitcoin::SigningKeys where V: ppv_lite86::types::MultiLane<T>
 pub fn psbt_v2::v0::bitcoin::SigningKeys::vzip(self) -> V
 pub struct psbt_v2::v0::bitcoin::Input
-pub psbt_v2::v0::bitcoin::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v0::bitcoin::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v0::bitcoin::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v0::bitcoin::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
 pub psbt_v2::v0::bitcoin::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
@@ -1026,7 +1026,7 @@ impl<T> serde::de::DeserializeOwned for psbt_v2::v0::Input where T: for<'de> ser
 impl<V, T> ppv_lite86::types::VZip<V> for psbt_v2::v0::Input where V: ppv_lite86::types::MultiLane<T>
 pub fn psbt_v2::v0::Input::vzip(self) -> V
 pub struct psbt_v2::v0::bitcoin::Output
-pub psbt_v2::v0::bitcoin::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v0::bitcoin::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v0::bitcoin::Output::proprietary: alloc::collections::btree::map::BTreeMap<psbt_v2::v0::bitcoin::raw::ProprietaryKey, alloc::vec::Vec<u8>>
 pub psbt_v2::v0::bitcoin::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v0::bitcoin::Output::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
@@ -1679,7 +1679,7 @@ pub fn psbt_v2::v0::SignerChecksError::from(t: T) -> T
 impl<V, T> ppv_lite86::types::VZip<V> for psbt_v2::v0::SignerChecksError where V: ppv_lite86::types::MultiLane<T>
 pub fn psbt_v2::v0::SignerChecksError::vzip(self) -> V
 pub struct psbt_v2::v0::Input
-pub psbt_v2::v0::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v0::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v0::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v0::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
 pub psbt_v2::v0::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
@@ -1755,7 +1755,7 @@ impl<T> serde::de::DeserializeOwned for psbt_v2::v0::Input where T: for<'de> ser
 impl<V, T> ppv_lite86::types::VZip<V> for psbt_v2::v0::Input where V: ppv_lite86::types::MultiLane<T>
 pub fn psbt_v2::v0::Input::vzip(self) -> V
 pub struct psbt_v2::v0::Output
-pub psbt_v2::v0::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v0::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v0::Output::proprietary: alloc::collections::btree::map::BTreeMap<psbt_v2::v0::bitcoin::raw::ProprietaryKey, alloc::vec::Vec<u8>>
 pub psbt_v2::v0::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v0::Output::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
@@ -2549,7 +2549,7 @@ pub fn psbt_v2::v2::input::HashPreimageError::from(t: T) -> T
 impl<V, T> ppv_lite86::types::VZip<V> for psbt_v2::v2::input::HashPreimageError where V: ppv_lite86::types::MultiLane<T>
 pub fn psbt_v2::v2::input::HashPreimageError::vzip(self) -> V
 pub struct psbt_v2::v2::input::Input
-pub psbt_v2::v2::input::Input::bip32_derivations: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v2::input::Input::bip32_derivations: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v2::input::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v2::input::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
 pub psbt_v2::v2::input::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
@@ -2808,7 +2808,7 @@ impl<V, T> ppv_lite86::types::VZip<V> for psbt_v2::v2::output::InsertPairError w
 pub fn psbt_v2::v2::output::InsertPairError::vzip(self) -> V
 pub struct psbt_v2::v2::output::Output
 pub psbt_v2::v2::output::Output::amount: bitcoin_units::amount::Amount
-pub psbt_v2::v2::output::Output::bip32_derivations: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v2::output::Output::bip32_derivations: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v2::output::Output::proprietaries: alloc::collections::btree::map::BTreeMap<psbt_v2::raw::ProprietaryKey, alloc::vec::Vec<u8>>
 pub psbt_v2::v2::output::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v2::output::Output::script_pubkey: bitcoin::blockdata::script::owned::ScriptBuf
@@ -4422,7 +4422,7 @@ impl<T> serde::de::DeserializeOwned for psbt_v2::v2::Global where T: for<'de> se
 impl<V, T> ppv_lite86::types::VZip<V> for psbt_v2::v2::Global where V: ppv_lite86::types::MultiLane<T>
 pub fn psbt_v2::v2::Global::vzip(self) -> V
 pub struct psbt_v2::v2::Input
-pub psbt_v2::v2::Input::bip32_derivations: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v2::Input::bip32_derivations: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v2::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v2::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
 pub psbt_v2::v2::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
@@ -4633,7 +4633,7 @@ impl<V, T> ppv_lite86::types::VZip<V> for psbt_v2::v2::dleq::InvalidLengthError 
 pub fn psbt_v2::v2::dleq::InvalidLengthError::vzip(self) -> V
 pub struct psbt_v2::v2::Output
 pub psbt_v2::v2::Output::amount: bitcoin_units::amount::Amount
-pub psbt_v2::v2::Output::bip32_derivations: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v2::Output::bip32_derivations: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v2::Output::proprietaries: alloc::collections::btree::map::BTreeMap<psbt_v2::raw::ProprietaryKey, alloc::vec::Vec<u8>>
 pub psbt_v2::v2::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v2::Output::script_pubkey: bitcoin::blockdata::script::owned::ScriptBuf

--- a/api/no-features.txt
+++ b/api/no-features.txt
@@ -836,7 +836,7 @@ pub unsafe fn psbt_v2::v0::bitcoin::SigningKeys::clone_to_uninit(&self, dest: *m
 impl<T> core::convert::From<T> for psbt_v2::v0::bitcoin::SigningKeys
 pub fn psbt_v2::v0::bitcoin::SigningKeys::from(t: T) -> T
 pub struct psbt_v2::v0::bitcoin::Input
-pub psbt_v2::v0::bitcoin::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v0::bitcoin::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v0::bitcoin::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v0::bitcoin::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
 pub psbt_v2::v0::bitcoin::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
@@ -903,7 +903,7 @@ pub unsafe fn psbt_v2::v0::Input::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for psbt_v2::v0::Input
 pub fn psbt_v2::v0::Input::from(t: T) -> T
 pub struct psbt_v2::v0::bitcoin::Output
-pub psbt_v2::v0::bitcoin::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v0::bitcoin::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v0::bitcoin::Output::proprietary: alloc::collections::btree::map::BTreeMap<psbt_v2::v0::bitcoin::raw::ProprietaryKey, alloc::vec::Vec<u8>>
 pub psbt_v2::v0::bitcoin::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v0::bitcoin::Output::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
@@ -1084,7 +1084,7 @@ pub unsafe fn psbt_v2::v0::SignerChecksError::clone_to_uninit(&self, dest: *mut 
 impl<T> core::convert::From<T> for psbt_v2::v0::SignerChecksError
 pub fn psbt_v2::v0::SignerChecksError::from(t: T) -> T
 pub struct psbt_v2::v0::Input
-pub psbt_v2::v0::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v0::Input::bip32_derivation: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v0::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v0::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
 pub psbt_v2::v0::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
@@ -1151,7 +1151,7 @@ pub unsafe fn psbt_v2::v0::Input::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for psbt_v2::v0::Input
 pub fn psbt_v2::v0::Input::from(t: T) -> T
 pub struct psbt_v2::v0::Output
-pub psbt_v2::v0::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v0::Output::bip32_derivation: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v0::Output::proprietary: alloc::collections::btree::map::BTreeMap<psbt_v2::v0::bitcoin::raw::ProprietaryKey, alloc::vec::Vec<u8>>
 pub psbt_v2::v0::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v0::Output::tap_internal_key: core::option::Option<secp256k1::key::XOnlyPublicKey>
@@ -1707,7 +1707,7 @@ pub unsafe fn psbt_v2::v2::input::HashPreimageError::clone_to_uninit(&self, dest
 impl<T> core::convert::From<T> for psbt_v2::v2::input::HashPreimageError
 pub fn psbt_v2::v2::input::HashPreimageError::from(t: T) -> T
 pub struct psbt_v2::v2::input::Input
-pub psbt_v2::v2::input::Input::bip32_derivations: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v2::input::Input::bip32_derivations: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v2::input::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v2::input::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
 pub psbt_v2::v2::input::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
@@ -1943,7 +1943,7 @@ impl<T> core::convert::From<T> for psbt_v2::v2::output::InsertPairError
 pub fn psbt_v2::v2::output::InsertPairError::from(t: T) -> T
 pub struct psbt_v2::v2::output::Output
 pub psbt_v2::v2::output::Output::amount: bitcoin_units::amount::Amount
-pub psbt_v2::v2::output::Output::bip32_derivations: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v2::output::Output::bip32_derivations: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v2::output::Output::proprietaries: alloc::collections::btree::map::BTreeMap<psbt_v2::raw::ProprietaryKey, alloc::vec::Vec<u8>>
 pub psbt_v2::v2::output::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v2::output::Output::script_pubkey: bitcoin::blockdata::script::owned::ScriptBuf
@@ -3065,7 +3065,7 @@ pub unsafe fn psbt_v2::v2::Global::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for psbt_v2::v2::Global
 pub fn psbt_v2::v2::Global::from(t: T) -> T
 pub struct psbt_v2::v2::Input
-pub psbt_v2::v2::Input::bip32_derivations: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v2::Input::bip32_derivations: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v2::Input::final_script_sig: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v2::Input::final_script_witness: core::option::Option<bitcoin::blockdata::witness::Witness>
 pub psbt_v2::v2::Input::hash160_preimages: alloc::collections::btree::map::BTreeMap<bitcoin_hashes::hash160::Hash, alloc::vec::Vec<u8>>
@@ -3214,7 +3214,7 @@ impl<T> core::convert::From<T> for psbt_v2::v2::InputsNotModifiableError
 pub fn psbt_v2::v2::InputsNotModifiableError::from(t: T) -> T
 pub struct psbt_v2::v2::Output
 pub psbt_v2::v2::Output::amount: bitcoin_units::amount::Amount
-pub psbt_v2::v2::Output::bip32_derivations: alloc::collections::btree::map::BTreeMap<secp256k1::key::PublicKey, bitcoin::bip32::KeySource>
+pub psbt_v2::v2::Output::bip32_derivations: alloc::collections::btree::map::BTreeMap<bitcoin::crypto::key::PublicKey, bitcoin::bip32::KeySource>
 pub psbt_v2::v2::Output::proprietaries: alloc::collections::btree::map::BTreeMap<psbt_v2::raw::ProprietaryKey, alloc::vec::Vec<u8>>
 pub psbt_v2::v2::Output::redeem_script: core::option::Option<bitcoin::blockdata::script::owned::ScriptBuf>
 pub psbt_v2::v2::Output::script_pubkey: bitcoin::blockdata::script::owned::ScriptBuf

--- a/examples/v0.rs
+++ b/examples/v0.rs
@@ -94,10 +94,10 @@ fn main() -> anyhow::Result<()> {
     let fake_fp: [u8; 4] = [0; 4];
     psbt.inputs[0]
         .bip32_derivation
-        .insert(alice.0.pk, (Fingerprint::from(fake_fp), DerivationPath::from_str("m")?));
+        .insert(alice.0.public_key(), (Fingerprint::from(fake_fp), DerivationPath::from_str("m")?));
     psbt.inputs[1]
         .bip32_derivation
-        .insert(bob.0.pk, (Fingerprint::from(fake_fp), DerivationPath::from_str("m")?));
+        .insert(bob.0.public_key(), (Fingerprint::from(fake_fp), DerivationPath::from_str("m")?));
 
     // Since we are spending 2 p2wpkh inputs there are no other updates needed.
 

--- a/examples/v2.rs
+++ b/examples/v2.rs
@@ -176,7 +176,7 @@ impl Alice {
     /// Provides the actual UTXO that Alice is contributing, this would usually come from the chain.
     fn input_utxo(&self) -> anyhow::Result<TxOut> { self.0.input_utxo(Self::PATH) }
 
-    fn bip32_derivation(&self) -> anyhow::Result<(secp256k1::PublicKey, KeySource)> {
+    fn bip32_derivation(&self) -> anyhow::Result<(PublicKey, KeySource)> {
         self.0.bip32_derivation(Self::PATH)
     }
 }
@@ -229,7 +229,7 @@ impl Bob {
     /// Provides the actual UTXO that Alice is contributing, this would usually come from the chain.
     fn input_utxo(&self) -> anyhow::Result<TxOut> { self.0.input_utxo(Self::PATH) }
 
-    fn bip32_derivation(&self) -> anyhow::Result<(secp256k1::PublicKey, KeySource)> {
+    fn bip32_derivation(&self) -> anyhow::Result<(PublicKey, KeySource)> {
         self.0.bip32_derivation(Self::PATH)
     }
 }
@@ -266,15 +266,12 @@ impl Entity {
     }
 
     /// Returns the BOP-32 stuff needed to sign an ECDSA input using the [`v2::Psbt`] BIP-32 signing API.
-    fn bip32_derivation(
-        &self,
-        derivation_path: &str,
-    ) -> anyhow::Result<(secp256k1::PublicKey, KeySource)> {
+    fn bip32_derivation(&self, derivation_path: &str) -> anyhow::Result<(PublicKey, KeySource)> {
         let path = DerivationPath::from_str(derivation_path)?;
         let xpriv = self.master.derive_priv(&self.secp, &path).expect("failed to derive xpriv");
         let fingerprint = xpriv.fingerprint(&self.secp);
         let sk = xpriv.to_priv();
-        Ok((sk.public_key(&self.secp).inner, (fingerprint, path)))
+        Ok((sk.public_key(&self.secp), (fingerprint, path)))
     }
 
     /// Signs any ECDSA inputs for which we have keys.

--- a/src/v0/bitcoin/map/input.rs
+++ b/src/v0/bitcoin/map/input.rs
@@ -8,7 +8,7 @@ use bitcoin::blockdata::transaction::{Transaction, TxOut};
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::hashes::{self, hash160, ripemd160, sha256, sha256d};
 use bitcoin::key::PublicKey;
-use bitcoin::secp256k1::{self, XOnlyPublicKey};
+use bitcoin::secp256k1::XOnlyPublicKey;
 use bitcoin::sighash::{EcdsaSighashType, NonStandardSighashTypeError, TapSighashType};
 use bitcoin::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapNodeHash};
 use bitcoin::{ecdsa, taproot};
@@ -96,7 +96,7 @@ pub struct Input {
     /// A map from public keys needed to sign this input to their corresponding
     /// master key fingerprints and derivation paths.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
-    pub bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
+    pub bip32_derivation: BTreeMap<PublicKey, KeySource>,
     /// The finalized, fully-constructed scriptSig with signatures and any other
     /// scripts necessary for this input to pass validation.
     pub final_script_sig: Option<ScriptBuf>,
@@ -199,7 +199,7 @@ impl Input {
             }
             PSBT_IN_BIP32_DERIVATION => {
                 impl_psbt_insert_pair! {
-                    self.bip32_derivation <= <raw_key: secp256k1::PublicKey>|<raw_value: KeySource>
+                    self.bip32_derivation <= <raw_key: PublicKey>|<raw_value: KeySource>
                 }
             }
             PSBT_IN_FINAL_SCRIPTSIG => {

--- a/src/v0/bitcoin/map/output.rs
+++ b/src/v0/bitcoin/map/output.rs
@@ -4,7 +4,8 @@ use core::convert::TryFrom;
 
 use bitcoin::bip32::KeySource;
 use bitcoin::blockdata::script::ScriptBuf;
-use bitcoin::secp256k1::{self, XOnlyPublicKey};
+use bitcoin::key::PublicKey;
+use bitcoin::secp256k1::XOnlyPublicKey;
 use bitcoin::taproot::{TapLeafHash, TapTree};
 
 use crate::prelude::*;
@@ -42,7 +43,7 @@ pub struct Output {
     /// A map from public keys needed to spend this output to their
     /// corresponding master key fingerprints and derivation paths.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
-    pub bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
+    pub bip32_derivation: BTreeMap<PublicKey, KeySource>,
     /// The internal pubkey.
     pub tap_internal_key: Option<XOnlyPublicKey>,
     /// Taproot Output tree.
@@ -75,7 +76,7 @@ impl Output {
             }
             PSBT_OUT_BIP32_DERIVATION => {
                 impl_psbt_insert_pair! {
-                    self.bip32_derivation <= <raw_key: secp256k1::PublicKey>|<raw_value: KeySource>
+                    self.bip32_derivation <= <raw_key: PublicKey>|<raw_value: KeySource>
                 }
             }
             PSBT_OUT_PROPRIETARY => {

--- a/src/v0/bitcoin/mod.rs
+++ b/src/v0/bitcoin/mod.rs
@@ -371,7 +371,7 @@ impl Psbt {
         for (pk, key_source) in input.bip32_derivation.iter() {
             let sk = if let Ok(Some(sk)) = k.get_key(KeyRequest::Bip32(key_source.clone()), secp) {
                 sk
-            } else if let Ok(Some(sk)) = k.get_key(KeyRequest::Pubkey(PublicKey::new(*pk)), secp) {
+            } else if let Ok(Some(sk)) = k.get_key(KeyRequest::Pubkey(*pk), secp) {
                 sk
             } else {
                 continue;
@@ -1228,7 +1228,7 @@ mod tests {
     use bitcoin::blockdata::witness::Witness;
     use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
     use bitcoin::hex::{test_hex_unwrap as hex, FromHex};
-    use bitcoin::secp256k1::{self, Secp256k1};
+    use bitcoin::secp256k1::Secp256k1;
     #[cfg(feature = "rand")]
     use bitcoin::secp256k1::{All, SecretKey};
     use bitcoin::NetworkKind;
@@ -1368,7 +1368,7 @@ mod tests {
         let secp = &Secp256k1::new();
         let seed = hex!("000102030405060708090a0b0c0d0e0f");
 
-        let mut hd_keypaths: BTreeMap<secp256k1::PublicKey, KeySource> = Default::default();
+        let mut hd_keypaths: BTreeMap<PublicKey, KeySource> = Default::default();
 
         let mut sk: Xpriv = Xpriv::new_master(NetworkKind::Main, &seed).unwrap();
 
@@ -1389,7 +1389,7 @@ mod tests {
 
         let pk = Xpub::from_priv(secp, &sk);
 
-        hd_keypaths.insert(pk.public_key, (fprint, dpath.into()));
+        hd_keypaths.insert(pk.public_key.into(), (fprint, dpath.into()));
 
         let expected: Output = Output {
             redeem_script: Some(
@@ -1511,7 +1511,7 @@ mod tests {
                 .into_iter()
                 .collect();
         let key_source = ("deadbeef".parse().unwrap(), "0'/1".parse().unwrap());
-        let keypaths: BTreeMap<secp256k1::PublicKey, KeySource> = vec![(
+        let keypaths: BTreeMap<bitcoin::PublicKey, KeySource> = vec![(
             "0339880dc92394b7355e3d0439fa283c31de7590812ea011c4245c0674a685e883".parse().unwrap(),
             key_source.clone(),
         )]
@@ -2306,7 +2306,7 @@ mod tests {
         psbt.inputs[0].witness_utxo = Some(txout_wpkh);
 
         let mut map = BTreeMap::new();
-        map.insert(pk.inner, (Fingerprint::default(), DerivationPath::default()));
+        map.insert(pk, (Fingerprint::default(), DerivationPath::default()));
         psbt.inputs[0].bip32_derivation = map;
 
         // Second input is unspendable by us e.g., from another wallet that supports future upgrades.

--- a/src/v0/miniscript/finalizer.rs
+++ b/src/v0/miniscript/finalizer.rs
@@ -148,7 +148,7 @@ fn get_descriptor(psbt: &Psbt, index: usize) -> Result<Descriptor<PublicKey>, In
         // Use BIP32 Derviation to get set of all possible keys.
         let public_keys = psbt_input.bip32_derivation.keys();
         for key in public_keys {
-            let bitcoin_key = bitcoin::PublicKey::new(*key);
+            let bitcoin_key = *key;
             let hash = bitcoin_key.pubkey_hash().to_raw_hash();
             map.insert(hash, bitcoin_key);
         }

--- a/src/v0/miniscript/mod.rs
+++ b/src/v0/miniscript/mod.rs
@@ -275,7 +275,7 @@ impl<'psbt, Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfie
             .bip32_derivation
             .iter()
             .find(|&(pubkey, _)| pubkey.to_pubkeyhash(SigType::Ecdsa) == *pkh)
-            .map(|(pubkey, _)| bitcoin::PublicKey::new(*pubkey))
+            .map(|(pubkey, _)| *pubkey)
     }
 
     fn lookup_tap_control_block_map(
@@ -970,7 +970,7 @@ impl PsbtOutputExt for Output {
 // Traverse the pkh lookup while maintaining a reverse map for storing the map
 // hash160 -> (XonlyPublicKey)/PublicKey
 struct KeySourceLookUp(
-    pub BTreeMap<secp256k1::PublicKey, bip32::KeySource>,
+    pub BTreeMap<bitcoin::PublicKey, bip32::KeySource>,
     pub secp256k1::Secp256k1<VerifyOnly>,
 );
 
@@ -983,7 +983,7 @@ impl Translator<DefiniteDescriptorKey, bitcoin::PublicKey, descriptor::Conversio
     ) -> Result<bitcoin::PublicKey, descriptor::ConversionError> {
         let derived = xpk.derive_public_key(&self.1)?;
         self.0.insert(
-            derived.to_public_key().inner,
+            derived.to_public_key(),
             (
                 xpk.master_fingerprint(),
                 xpk.full_derivation_path()
@@ -1001,7 +1001,7 @@ trait PsbtFields {
     // Common fields are returned as a mutable ref of the same type
     fn redeem_script(&mut self) -> &mut Option<ScriptBuf>;
     fn witness_script(&mut self) -> &mut Option<ScriptBuf>;
-    fn bip32_derivation(&mut self) -> &mut BTreeMap<secp256k1::PublicKey, bip32::KeySource>;
+    fn bip32_derivation(&mut self) -> &mut BTreeMap<bitcoin::PublicKey, bip32::KeySource>;
     fn tap_internal_key(&mut self) -> &mut Option<bitcoin::key::XOnlyPublicKey>;
     fn tap_key_origins(
         &mut self,
@@ -1024,7 +1024,7 @@ trait PsbtFields {
 impl PsbtFields for Input {
     fn redeem_script(&mut self) -> &mut Option<ScriptBuf> { &mut self.redeem_script }
     fn witness_script(&mut self) -> &mut Option<ScriptBuf> { &mut self.witness_script }
-    fn bip32_derivation(&mut self) -> &mut BTreeMap<secp256k1::PublicKey, bip32::KeySource> {
+    fn bip32_derivation(&mut self) -> &mut BTreeMap<bitcoin::PublicKey, bip32::KeySource> {
         &mut self.bip32_derivation
     }
     fn tap_internal_key(&mut self) -> &mut Option<bitcoin::key::XOnlyPublicKey> {
@@ -1053,7 +1053,7 @@ impl PsbtFields for Input {
 impl PsbtFields for Output {
     fn redeem_script(&mut self) -> &mut Option<ScriptBuf> { &mut self.redeem_script }
     fn witness_script(&mut self) -> &mut Option<ScriptBuf> { &mut self.witness_script }
-    fn bip32_derivation(&mut self) -> &mut BTreeMap<secp256k1::PublicKey, bip32::KeySource> {
+    fn bip32_derivation(&mut self) -> &mut BTreeMap<bitcoin::PublicKey, bip32::KeySource> {
         &mut self.bip32_derivation
     }
     fn tap_internal_key(&mut self) -> &mut Option<bitcoin::key::XOnlyPublicKey> {
@@ -1409,8 +1409,7 @@ mod tests {
     use bitcoin::bip32::{DerivationPath, Xpub};
     use bitcoin::consensus::encode::deserialize;
     use bitcoin::hashes::hex::FromHex;
-    use bitcoin::key::XOnlyPublicKey;
-    use bitcoin::secp256k1::PublicKey;
+    use bitcoin::key::{PublicKey, XOnlyPublicKey};
     use bitcoin::{absolute, Amount, OutPoint, TxIn, TxOut};
 
     use super::*;

--- a/src/v2/map/input.rs
+++ b/src/v2/map/input.rs
@@ -14,8 +14,7 @@ use bitcoin::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapNodeHash};
 #[cfg(feature = "silent-payments")]
 use bitcoin::CompressedPublicKey;
 use bitcoin::{
-    ecdsa, hashes, secp256k1, taproot, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
-    Txid, Witness,
+    ecdsa, hashes, taproot, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 
 use crate::consts::{
@@ -85,7 +84,7 @@ pub struct Input {
     /// A map from public keys needed to sign this input to their corresponding
     /// master key fingerprints and derivation paths.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
-    pub bip32_derivations: BTreeMap<secp256k1::PublicKey, KeySource>,
+    pub bip32_derivations: BTreeMap<PublicKey, KeySource>,
     /// The finalized, fully-constructed scriptSig with signatures and any other
     /// scripts necessary for this input to pass validation.
     pub final_script_sig: Option<ScriptBuf>,
@@ -489,7 +488,7 @@ impl Input {
             }
             PSBT_IN_BIP32_DERIVATION => {
                 v2_impl_psbt_insert_pair! {
-                    self.bip32_derivations <= <raw_key: secp256k1::PublicKey>|<raw_value: KeySource>
+                    self.bip32_derivations <= <raw_key: PublicKey>|<raw_value: KeySource>
                 }
             }
             PSBT_IN_FINAL_SCRIPTSIG => {

--- a/src/v2/map/output.rs
+++ b/src/v2/map/output.rs
@@ -5,9 +5,9 @@ use core::fmt;
 
 use bitcoin::bip32::KeySource;
 use bitcoin::io::BufRead;
-use bitcoin::key::XOnlyPublicKey;
+use bitcoin::key::{PublicKey, XOnlyPublicKey};
 use bitcoin::taproot::{TapLeafHash, TapTree};
-use bitcoin::{secp256k1, Amount, ScriptBuf, TxOut};
+use bitcoin::{Amount, ScriptBuf, TxOut};
 
 use crate::consts::{
     PSBT_OUT_AMOUNT, PSBT_OUT_BIP32_DERIVATION, PSBT_OUT_PROPRIETARY, PSBT_OUT_REDEEM_SCRIPT,
@@ -40,7 +40,7 @@ pub struct Output {
     /// A map from public keys needed to spend this output to their
     /// corresponding master key fingerprints and derivation paths.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_utils::btreemap_as_seq"))]
-    pub bip32_derivations: BTreeMap<secp256k1::PublicKey, KeySource>,
+    pub bip32_derivations: BTreeMap<PublicKey, KeySource>,
     /// The internal pubkey.
     pub tap_internal_key: Option<XOnlyPublicKey>,
     /// Taproot Output tree.
@@ -166,7 +166,7 @@ impl Output {
             }
             PSBT_OUT_BIP32_DERIVATION => {
                 v2_impl_psbt_insert_pair! {
-                    self.bip32_derivations <= <raw_key: secp256k1::PublicKey>|<raw_value: KeySource>
+                    self.bip32_derivations <= <raw_key: PublicKey>|<raw_value: KeySource>
                 }
             }
             PSBT_OUT_PROPRIETARY => {

--- a/src/v2/miniscript/finalize.rs
+++ b/src/v2/miniscript/finalize.rs
@@ -144,7 +144,7 @@ impl Finalizer {
             // Use BIP32 Derviation to get set of all possible keys.
             let public_keys = psbt_input.bip32_derivations.keys();
             for key in public_keys {
-                let bitcoin_key = bitcoin::PublicKey::new(*key);
+                let bitcoin_key = *key;
                 let hash = bitcoin_key.pubkey_hash().to_raw_hash();
                 map.insert(hash, bitcoin_key);
             }

--- a/src/v2/miniscript/satisfy.rs
+++ b/src/v2/miniscript/satisfy.rs
@@ -30,7 +30,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for InputSatisfier<'_> {
             .bip32_derivations
             .iter()
             .find(|&(pubkey, _)| pubkey.to_pubkeyhash(SigType::Ecdsa) == *pkh)
-            .map(|(pubkey, _)| bitcoin::PublicKey::new(*pubkey))
+            .map(|(pubkey, _)| *pubkey)
     }
 
     fn lookup_tap_control_block_map(

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -787,7 +787,7 @@ impl Psbt {
         for (pk, key_source) in input.bip32_derivations.iter() {
             let sk = if let Ok(Some(sk)) = k.get_key(KeyRequest::Bip32(key_source.clone()), secp) {
                 sk
-            } else if let Ok(Some(sk)) = k.get_key(KeyRequest::Pubkey(PublicKey::new(*pk)), secp) {
+            } else if let Ok(Some(sk)) = k.get_key(KeyRequest::Pubkey(*pk), secp) {
                 sk
             } else {
                 continue;

--- a/tests/bip174.rs
+++ b/tests/bip174.rs
@@ -14,7 +14,7 @@ use psbt_v2::bitcoin::blockdata::{script, transaction};
 use psbt_v2::bitcoin::consensus::encode::{deserialize, serialize_hex};
 use psbt_v2::bitcoin::hex::FromHex;
 use psbt_v2::bitcoin::script::PushBytes;
-use psbt_v2::bitcoin::secp256k1::{self, Secp256k1};
+use psbt_v2::bitcoin::secp256k1::Secp256k1;
 use psbt_v2::bitcoin::{
     absolute, Amount, Denomination, Network, OutPoint, PrivateKey, PublicKey, ScriptBuf, Sequence,
     Transaction, TxIn, TxOut, Witness,
@@ -278,7 +278,7 @@ fn bip32_derivation(
     fingerprint: Fingerprint,
     pk_path: &[(&str, &str)],
     indecies: Vec<usize>,
-) -> BTreeMap<secp256k1::PublicKey, KeySource> {
+) -> BTreeMap<PublicKey, KeySource> {
     let mut tree = BTreeMap::new();
     for i in indecies {
         let pk = pk_path[i].0;
@@ -287,7 +287,7 @@ fn bip32_derivation(
         let pk = PublicKey::from_str(pk).unwrap();
         let path = path.into_derivation_path().unwrap();
 
-        tree.insert(pk.inner, (fingerprint, path));
+        tree.insert(pk, (fingerprint, path));
     }
     tree
 }


### PR DESCRIPTION
The bip32_derivation fields on Input and Output currently take BTreeMaps from secp256k1::PublicKey to KeySource. Most locations where these maps are constructed convert from the bitcoin type to the secp type. Further, the secp type can be trivially converted to the PublicKey type unambiguously in other places.

This change also prevents PSBTs from silently reserialising uncompressed keys in a compressed form, eliminating a footgun.

Convert bip32_derivation fields on Input and Output to take bitcoin PublicKey instead of secp256k1, and change all relevant uses.

Closes #76 