### PR TITLE
Use u64 for ProprietaryKey subtype

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -14,7 +14,7 @@ use core::fmt;
 
 use bitcoin::consensus::encode as consensus;
 use bitcoin::consensus::encode::{
-    deserialize, serialize, Decodable, Encodable, ReadExt, VarInt, WriteExt, MAX_VEC_SIZE,
+    deserialize, serialize, Decodable, Encodable, VarInt, MAX_VEC_SIZE,
 };
 use bitcoin::hex::DisplayHex;
 
@@ -140,7 +140,7 @@ impl Serialize for Key {
 }
 
 /// Default implementation for proprietary key subtyping
-pub type ProprietaryType = u8;
+pub type ProprietaryType = u64;
 
 /// Proprietary keys (i.e. keys starting with 0xFC byte) with their internal
 /// structure according to BIP 174.
@@ -148,7 +148,7 @@ pub type ProprietaryType = u8;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProprietaryKey<Subtype = ProprietaryType>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     /// Proprietary type prefix used for grouping together keys under some
     /// application and avoid namespace collision
@@ -163,7 +163,7 @@ where
 
 impl<Subtype> ProprietaryKey<Subtype>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     /// Constructs full [Key] corresponding to this proprietary key type
     pub fn to_key(&self) -> Key { Key { type_value: 0xFC, key: serialize(self) } }
@@ -171,7 +171,7 @@ where
 
 impl<Subtype> TryFrom<Key> for ProprietaryKey<Subtype>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     type Error = serialize::Error;
 
@@ -191,11 +191,11 @@ where
 
 impl<Subtype> Encodable for ProprietaryKey<Subtype>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        let mut len = self.prefix.consensus_encode(w)? + 1;
-        w.emit_u8(self.subtype.into())?;
+        let mut len = self.prefix.consensus_encode(w)?;
+        len += VarInt::from(self.subtype.into()).consensus_encode(w)?;
         w.write_all(&self.key)?;
         len += self.key.len();
         Ok(len)
@@ -204,11 +204,12 @@ where
 
 impl<Subtype> Decodable for ProprietaryKey<Subtype>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, consensus::Error> {
         let prefix = Vec::<u8>::consensus_decode(r)?;
-        let subtype = Subtype::from(r.read_u8()?);
+        let VarInt(subtype_u64): VarInt = Decodable::consensus_decode(r)?;
+        let subtype = Subtype::from(subtype_u64);
 
         // The limit is a DOS protection mechanism the exact value is not
         // important, 1024 bytes is bigger than any key should be.

--- a/src/v0/bitcoin/mod.rs
+++ b/src/v0/bitcoin/mod.rs
@@ -2174,7 +2174,7 @@ mod tests {
     fn serialize_and_deserialize_proprietary() {
         let mut psbt: Psbt = hex_psbt("70736274ff0100a00200000002ab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40000000000feffffffab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40100000000feffffff02603bea0b000000001976a914768a40bbd740cbe81d988e71de2a4d5c71396b1d88ac8e240000000000001976a9146f4620b553fa095e721b9ee0efe9fa039cca459788ac000000000001076a47304402204759661797c01b036b25928948686218347d89864b719e1f7fcf57d1e511658702205309eabf56aa4d8891ffd111fdf1336f3a29da866d7f8486d75546ceedaf93190121035cdc61fc7ba971c0b501a646a2a83b102cb43881217ca682dc86e2d73fa882920001012000e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787010416001485d13537f2e265405a34dbafa9e3dda01fb82308000000").unwrap();
         psbt.proprietary.insert(
-            raw::ProprietaryKey { prefix: b"test".to_vec(), subtype: 0u8, key: b"test".to_vec() },
+            raw::ProprietaryKey { prefix: b"test".to_vec(), subtype: 0u64, key: b"test".to_vec() },
             b"test".to_vec(),
         );
         assert!(!psbt.proprietary.is_empty());

--- a/src/v0/bitcoin/raw.rs
+++ b/src/v0/bitcoin/raw.rs
@@ -10,7 +10,7 @@ use core::convert::TryFrom;
 use core::fmt;
 
 use bitcoin::consensus::encode::{
-    self, deserialize, serialize, Decodable, Encodable, ReadExt, VarInt, WriteExt, MAX_VEC_SIZE,
+    self, deserialize, serialize, Decodable, Encodable, VarInt, MAX_VEC_SIZE,
 };
 
 use super::serialize::{Deserialize, Serialize};
@@ -44,7 +44,7 @@ pub struct Pair {
 }
 
 /// Default implementation for proprietary key subtyping
-pub type ProprietaryType = u8;
+pub type ProprietaryType = u64;
 
 /// Proprietary keys (i.e. keys starting with 0xFC byte) with their internal
 /// structure according to BIP 174.
@@ -52,7 +52,7 @@ pub type ProprietaryType = u8;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProprietaryKey<Subtype = ProprietaryType>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     /// Proprietary type prefix used for grouping together keys under some
     /// application and avoid namespace collision
@@ -152,11 +152,11 @@ impl Pair {
 
 impl<Subtype> Encodable for ProprietaryKey<Subtype>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        let mut len = self.prefix.consensus_encode(w)? + 1;
-        w.emit_u8(self.subtype.into())?;
+        let mut len = self.prefix.consensus_encode(w)?;
+        len += VarInt::from(self.subtype.into()).consensus_encode(w)?;
         w.write_all(&self.key)?;
         len += self.key.len();
         Ok(len)
@@ -165,11 +165,12 @@ where
 
 impl<Subtype> Decodable for ProprietaryKey<Subtype>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let prefix = Vec::<u8>::consensus_decode(r)?;
-        let subtype = Subtype::from(r.read_u8()?);
+        let VarInt(subtype_u64): VarInt = Decodable::consensus_decode(r)?;
+        let subtype = Subtype::from(subtype_u64);
 
         // The limit is a DOS protection mechanism the exact value is not
         // important, 1024 bytes is bigger than any key should be.
@@ -182,7 +183,7 @@ where
 
 impl<Subtype> ProprietaryKey<Subtype>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     /// Constructs full [Key] corresponding to this proprietary key type
     pub fn to_key(&self) -> Key { Key { type_value: 0xFC, key: serialize(self) } }
@@ -190,7 +191,7 @@ where
 
 impl<Subtype> TryFrom<Key> for ProprietaryKey<Subtype>
 where
-    Subtype: Copy + From<u8> + Into<u8>,
+    Subtype: Copy + From<u64> + Into<u64>,
 {
     type Error = Error;
 
@@ -212,7 +213,7 @@ impl<'a> arbitrary::Arbitrary<'a> for ProprietaryKey {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(ProprietaryKey {
             prefix: Vec::<u8>::arbitrary(u)?,
-            subtype: u8::arbitrary(u)?,
+            subtype: u64::arbitrary(u)?,
             key: Vec::<u8>::arbitrary(u)?,
         })
     }


### PR DESCRIPTION
Related to #78.
Fixes #100 