### PR TITLE
Expose raw key-value pairs on v2 Map types

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -114,7 +114,7 @@ pub(crate) const PSBT_OUT_SP_V0_INFO: u64 = 0x09;
 #[cfg(feature = "silent-payments")]
 /// Type: Silent Payment v0 Label PSBT_OUT_SP_V0_LABEL = 0x0A
 pub(crate) const PSBT_OUT_SP_V0_LABEL: u64 = 0x0A;
-/// Type: Proprietary Use Type PSBT_IN_PROPRIETARY = 0xFC
+/// Type: Proprietary Use Type PSBT_OUT_PROPRIETARY = 0xFC
 pub(crate) const PSBT_OUT_PROPRIETARY: u64 = 0xFC;
 
 /// Converts a global key type value consts to a string, useful for debugging.

--- a/src/v2/map/global.rs
+++ b/src/v2/map/global.rs
@@ -100,6 +100,9 @@ impl Global {
         }
     }
 
+    /// Returns all key-value pairs for this global map in serialization order.
+    pub fn pairs(&self) -> Vec<raw::Pair> { Map::get_pairs(self) }
+
     pub(crate) fn set_inputs_modifiable_flag(&mut self) {
         self.tx_modifiable_flags |= INPUTS_MODIFIABLE;
     }

--- a/src/v2/map/global.rs
+++ b/src/v2/map/global.rs
@@ -784,3 +784,21 @@ impl std::error::Error for CombineError {
 impl From<InconsistentKeySourcesError> for CombineError {
     fn from(e: InconsistentKeySourcesError) -> Self { Self::InconsistentKeySources(e) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pairs_matches_serialize_map() {
+        let global = Global::default();
+
+        let mut from_pairs = Vec::new();
+        for pair in global.pairs() {
+            from_pairs.extend(pair.serialize());
+        }
+        from_pairs.push(0x00);
+
+        assert_eq!(from_pairs, global.serialize_map());
+    }
+}

--- a/src/v2/map/input.rs
+++ b/src/v2/map/input.rs
@@ -1120,4 +1120,17 @@ mod test {
 
         assert_eq!(decoded, input);
     }
+
+    #[test]
+    fn pairs_matches_serialize_map() {
+        let input = Input::new(&out_point());
+
+        let mut from_pairs = Vec::new();
+        for pair in input.pairs() {
+            from_pairs.extend(pair.serialize());
+        }
+        from_pairs.push(0x00);
+
+        assert_eq!(from_pairs, input.serialize_map());
+    }
 }

--- a/src/v2/map/input.rs
+++ b/src/v2/map/input.rs
@@ -175,6 +175,9 @@ impl Input {
         }
     }
 
+    /// Returns all key-value pairs for this input map in serialization order.
+    pub fn pairs(&self) -> Vec<raw::Pair> { Map::get_pairs(self) }
+
     // /// Converts this `Input` to a `v0::Input`.
     // pub(crate) fn into_v0(self) -> v0::Input {
     //     v0::Input {

--- a/src/v2/map/output.rs
+++ b/src/v2/map/output.rs
@@ -520,4 +520,17 @@ mod tests {
 
         assert_eq!(decoded, output);
     }
+
+    #[test]
+    fn pairs_matches_serialize_map() {
+        let output = Output::new(tx_out());
+
+        let mut from_pairs = Vec::new();
+        for pair in output.pairs() {
+            from_pairs.extend(pair.serialize());
+        }
+        from_pairs.push(0x00);
+
+        assert_eq!(from_pairs, output.serialize_map());
+    }
 }

--- a/src/v2/map/output.rs
+++ b/src/v2/map/output.rs
@@ -86,6 +86,9 @@ impl Output {
         }
     }
 
+    /// Returns all key-value pairs for this output map in serialization order.
+    pub fn pairs(&self) -> Vec<raw::Pair> { Map::get_pairs(self) }
+
     // /// Converts this `Output` to a `v0::Output`.
     // pub(crate) fn into_v0(self) -> v0::Output {
     //     v0::Output {


### PR DESCRIPTION
Provides downstream consumers a way iterate all fields of a PSBT map.  Without this consumers must duplicate field mapping for each Map.

Also fixes a small doc typo.