### PR TITLE
Update nightly toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.74.0"
 exclude = ["api", "tests", "contrib"]
 
 [package.metadata.rbmt.toolchains]
-nightly = "nightly-2026-03-30"
+nightly = "nightly-2026-04-11"
 stable = "1.94.1"
 
 [package.metadata.rbmt.test]


### PR DESCRIPTION
Automated update to `nightly-version` by [update-nightly](https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools) action.