### PR TITLE
Update stable toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["api", "tests", "contrib"]
 
 [package.metadata.rbmt.toolchains]
 nightly = "nightly-2026-03-30"
-stable = "1.94.1"
+stable = "1.95.0"
 
 [package.metadata.rbmt.test]
 examples = [


### PR DESCRIPTION
Automated update to `stable-version` by [update-stable](https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools) action.